### PR TITLE
Add The Classless Hero project to portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Weekly AI Prototypes
+## 1. Media Artist Minje Jeon Portfolio Site
+- **URL**: https://www.minjejeon.com/
+- **Background**: Portfolio site of media artist Minje Jeon, based in South Korea.
+  Created to showcase his various works and career using data and AI.
+- **Release Date**: 2025-05-03
+
+## 2. The Classless Hero
+- **URL**: https://classless-hero.unfold-ing.com/
+- **Background**: A web-based turn-based RPG that uses type-matchup mechanics.
+- **Release Date**: 2025-06-07
+
+## 3. Creative Guild Unfold-ing Official Site
+- **URL**: https://unfold-ing.com/
+- **Background**: Official site for the creative guild Unfold-ing, a collective solving world problems
+  through art, consulting, game and service development.
+- **Release Date**: 2025-06-09


### PR DESCRIPTION
## Summary
- add The Classless Hero turn-based RPG project with link, background, and 2025-06-07 release date
- renumber Creative Guild Unfold-ing official site as third portfolio entry

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c018854832f9237e1ba11634f87