### PR TITLE
Add Image Pattern Extractor to portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Weekly AI Prototypes
+## 1. Media Artist Minje Jeon Portfolio Site
+- **URL**: https://www.minjejeon.com/
+- **Background**: Portfolio site of media artist Minje Jeon, based in South Korea.
+  Created to showcase his various works and career using data and AI.
+- **Release Date**: 2025-05-03
+
+## 2. The Classless Hero
+- **URL**: https://classless-hero.unfold-ing.com/
+- **Background**: A web-based turn-based RPG that uses type-matchup mechanics.
+- **Release Date**: 2025-06-07
+
+## 3. Creative Guild Unfold-ing Official Site
+- **URL**: https://unfold-ing.com/
+- **Background**: Official site for the creative guild Unfold-ing, a collective solving world problems
+  through art, consulting, game and service development.
+- **Release Date**: 2025-06-09
+
+## 4. Let There Be Light
+- **URL**: https://splendid-naiad-1166a5.netlify.app/
+- **Background**: Text-driven emergent simulation game.
+  Hackathon project: https://devpost.com/software/let-there-be-light-y3tak4
+- **Release Date**: 2025-06-13
+
+## 5. Deaf Webtoon Creator Assistant
+- **URL**: https://v0-3-250801-13390365319.us-west1.run.app/
+- **Background**: Creative assistant service for deaf webtoon artists. Developed through SK hynix
+  and Root Impact's "AI for Impact" program at the 2nd Korea Social Value Festa. Interviews and
+  mentoring with deaf creators surfaced pain points and informed tools to address them.
+- **Press Release**: https://www.popcornnews.net/news/articleView.html?idxno=91589
+- **Release Date**: 2025-08-01
+
+## 6. Image Pattern Extractor
+- **URL**: https://image-pattern-extractor-38778985419.us-west1.run.app/
+- **Background**: Visual pattern extraction service for urban images, built for personal art projects
+  and arts education programs. Upload city photos to capture and visualize hidden patterns and
+  visual elements using various algorithms.
+- **Example**: https://www.instagram.com/share/BAFu1aSsOW
+- **Release Date**: 2025-08-10


### PR DESCRIPTION
## Summary
- document Let There Be Light emergent simulation project with live link, hackathon info, and 2025-06-13 release date
- add deaf webtoon creator assistant with live demo, background, Popcorn News press release link, and 2025-08-01 release date
- add image pattern extractor with demo URL, background, Instagram example post, and 2025-08-10 release date
- simplify Image Pattern Extractor example label

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5c018854832f9237e1ba11634f87